### PR TITLE
feat: add accessible theme system and layout

### DIFF
--- a/__tests__/Header.test.js
+++ b/__tests__/Header.test.js
@@ -10,11 +10,11 @@ jest.mock('next/router', () => ({
 describe('Header', () => {
   it('renders navigation links', async () => {
     render(<Header />);
-    const button = screen.getByLabelText(/toggle navigation/i);
+    const button = screen.getByLabelText(/open menu/i);
     await userEvent.click(button);
-    expect(screen.getByText('Home')).toBeInTheDocument();
-    expect(screen.getByText('Projects')).toBeInTheDocument();
-    expect(screen.getByText('About')).toBeInTheDocument();
-    expect(screen.getByText('Contact')).toBeInTheDocument();
+    expect(screen.getAllByText('Home').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Projects').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('About').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('Contact').length).toBeGreaterThan(0);
   });
 });

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,11 +1,11 @@
 export default function Footer() {
   return (
-    <footer className="py-6 text-center text-sm text-gray-500 border-t mt-8">
+    <footer className="py-6 text-center text-sm text-gray-500 dark:text-gray-400 border-t border-gray-200 dark:border-gray-700 mt-8">
       <div className="flex justify-center gap-4 mb-2">
         <a
           href="https://github.com/khalidkhan76770"
           aria-label="GitHub"
-          className="hover:text-black"
+          className="hover:text-black dark:hover:text-white"
           target="_blank"
           rel="noopener noreferrer"
         >
@@ -35,8 +35,8 @@ export default function Footer() {
           </svg>
         </a>
       </div>
-      <p>© {new Date().getFullYear()} Khalid Khan</p>
-      <a href="#" className="block mt-2 text-blue-600">
+      <p className="dark:text-gray-400">© {new Date().getFullYear()} Khalid Khan</p>
+      <a href="#" className="block mt-2 text-blue-600 hover:underline">
         Back to top
       </a>
     </footer>

--- a/components/Header.js
+++ b/components/Header.js
@@ -1,20 +1,86 @@
-import Link from "next/link";
-import { useRouter } from "next/router";
-import { useState } from "react";
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useRef, useState } from 'react';
 
 const navItems = [
-  { href: "/", label: "Home" },
-  { href: "/projects", label: "Projects" },
-  { href: "/about", label: "About" },
-  { href: "/contact", label: "Contact" },
+  { href: '/', label: 'Home' },
+  { href: '/projects', label: 'Projects' },
+  { href: '/about', label: 'About' },
+  { href: '/contact', label: 'Contact' },
 ];
 
 export default function Header() {
   const router = useRouter();
   const [open, setOpen] = useState(false);
+  const [mounted, setMounted] = useState(false);
+  const [theme, setTheme] = useState('light');
+  const menuRef = useRef(null);
+
+  useEffect(() => {
+    setMounted(true);
+    const stored = window.localStorage.getItem('theme');
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark');
+    } else {
+      document.documentElement.classList.remove('dark');
+    }
+    window.localStorage.setItem('theme', theme);
+  }, [theme, mounted]);
+
+  useEffect(() => {
+    if (!open) return;
+    const focusable = menuRef.current.querySelectorAll('a, button');
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    function handleKey(e) {
+      if (e.key === 'Escape') {
+        setOpen(false);
+      } else if (e.key === 'Tab') {
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    }
+    document.addEventListener('keydown', handleKey);
+    first?.focus();
+    return () => document.removeEventListener('keydown', handleKey);
+  }, [open]);
+
+  const toggleTheme = () => setTheme(theme === 'dark' ? 'light' : 'dark');
+
+  const navLinks = navItems.map(({ href, label }) => (
+    <Link
+      key={href}
+      href={href}
+      aria-current={router.pathname === href ? 'page' : undefined}
+      className={`block px-2 py-1 rounded transition-colors hover:text-blue-600 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 ${
+        router.pathname === href ? 'text-blue-600 font-semibold' : 'text-gray-700 dark:text-gray-300'
+      }`}
+      onClick={() => setOpen(false)}
+    >
+      {label}
+    </Link>
+  ));
 
   return (
-    <header className="sticky top-0 backdrop-blur bg-white/80 shadow z-10">
+    <header className="sticky top-0 backdrop-blur bg-white/80 dark:bg-gray-800/80 shadow z-10">
       <div className="max-w-4xl mx-auto flex justify-between items-center px-6 py-4">
         <Link href="/" className="flex items-center space-x-2">
           <img
@@ -26,44 +92,58 @@ export default function Header() {
             Khalid Khan
           </span>
         </Link>
-
-        <button
-          className="md:hidden"
-          onClick={() => setOpen(!open)}
-          aria-label="Toggle navigation"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth={1.5}
-            stroke="currentColor"
-            className="w-6 h-6"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5"
-            />
-          </svg>
-        </button>
-
-        <nav
-          className={`${open ? "block" : "hidden"} md:block space-y-2 md:space-y-0 md:space-x-6 md:flex`}
-        >
-          {navItems.map(({ href, label }) => (
-            <Link
-              key={href}
-              href={href}
-              className={`block md:inline px-2 py-1 rounded transition-colors hover:text-blue-600 ${
-                router.pathname === href ? "text-blue-600 font-semibold" : "text-gray-700"
-              }`}
+        <div className="flex items-center gap-4">
+          {mounted && (
+            <button
+              onClick={toggleTheme}
+              aria-label="Toggle theme"
+              className="p-2 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
             >
-              {label}
-            </Link>
-          ))}
+              {theme === 'dark' ? (
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+                  <path d="M12 3.75a.75.75 0 01.75-.75A8.25 8.25 0 1020.25 12a.75.75 0 01-.75-.75A8.25 8.25 0 0112 3.75z" />
+                </svg>
+              ) : (
+                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
+                  <path d="M12 2.25a.75.75 0 01.75.75V5a.75.75 0 01-1.5 0V3a.75.75 0 01.75-.75zM12 19a.75.75 0 01.75.75V21a.75.75 0 01-1.5 0v-1.25A.75.75 0 0112 19zm9-7a.75.75 0 01.75.75v1.5a.75.75 0 01-1.5 0V12.75a.75.75 0 01.75-.75zM4 12a.75.75 0 01.75-.75h1.5a.75.75 0 010 1.5H4.75A.75.75 0 014 12zm12.364 5.657a.75.75 0 01.53-1.28.75.75 0 01.53.22l1.06 1.06a.75.75 0 01-1.06 1.06l-1.06-1.06a.75.75 0 01-.22-.53zM6.53 6.53a.75.75 0 011.06 0l1.06 1.06a.75.75 0 11-1.06 1.06L6.53 7.59a.75.75 0 010-1.06zm10.6-1.06a.75.75 0 10-1.06-1.06l-1.06 1.06a.75.75 0 101.06 1.06l1.06-1.06zM7.59 17.47a.75.75 0 00-1.06 1.06l1.06 1.06a.75.75 0 001.06-1.06l-1.06-1.06z" />
+                </svg>
+              )}
+            </button>
+          )}
+          <button
+            className="md:hidden p-2 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+            onClick={() => setOpen(true)}
+            aria-label="Open menu"
+            aria-controls="mobile-menu"
+            aria-expanded={open}
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5m-16.5 6.75h16.5" />
+            </svg>
+          </button>
+        </div>
+        <nav id="desktop-nav" className="hidden md:flex space-x-6">
+          {navLinks}
         </nav>
       </div>
+      {open && (
+        <div
+          id="mobile-menu"
+          ref={menuRef}
+          className="md:hidden fixed inset-0 bg-white dark:bg-gray-800 p-6 flex flex-col space-y-4"
+        >
+          <button
+            onClick={() => setOpen(false)}
+            className="self-end p-2 mb-4 rounded focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+            aria-label="Close menu"
+          >
+            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" className="w-6 h-6">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          {navLinks}
+        </div>
+      )}
     </header>
   );
 }

--- a/components/ProjectCard.js
+++ b/components/ProjectCard.js
@@ -1,18 +1,18 @@
 export default function ProjectCard({ title, description, image, link, github, tech = [] }) {
   return (
-    <div className="group border rounded-lg overflow-hidden shadow-sm hover:shadow-lg transition-shadow flex flex-col">
+    <div className="group border rounded-lg overflow-hidden shadow-sm hover:shadow-lg transition-shadow flex flex-col bg-white dark:bg-gray-800 dark:border-gray-700">
       <img
         src={image}
         alt={title}
         className="w-full h-48 object-cover group-hover:scale-105 transition-transform duration-300"
       />
       <div className="p-4 flex flex-col flex-1">
-        <h3 className="font-semibold mb-1 text-lg">{title}</h3>
-        <p className="text-sm text-gray-600 flex-1">{description}</p>
+        <h3 className="font-semibold mb-1 text-lg text-gray-900 dark:text-gray-100">{title}</h3>
+        <p className="text-sm text-gray-600 dark:text-gray-300 flex-1">{description}</p>
         {tech.length > 0 && (
           <ul className="flex flex-wrap gap-2 mt-3 text-xs">
             {tech.map((t) => (
-              <li key={t} className="px-2 py-1 bg-blue-100 text-blue-700 rounded">
+              <li key={t} className="px-2 py-1 bg-blue-100 text-blue-700 rounded dark:bg-blue-900 dark:text-blue-100">
                 {t}
               </li>
             ))}
@@ -34,7 +34,7 @@ export default function ProjectCard({ title, description, image, link, github, t
               href={github}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-gray-600 hover:underline"
+              className="text-gray-600 dark:text-gray-300 hover:underline"
             >
               Code
             </a>

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,1 +1,14 @@
 import '@testing-library/jest-dom';
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: (query) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+});

--- a/pages/404.js
+++ b/pages/404.js
@@ -1,0 +1,15 @@
+import Layout from "../components/Layout";
+import Link from "next/link";
+
+export default function NotFound() {
+  return (
+    <Layout>
+      <div className="text-center py-20">
+        <h1 className="text-4xl font-bold mb-4">Page not found</h1>
+        <Link href="/" className="text-blue-600 hover:underline">
+          Back home
+        </Link>
+      </div>
+    </Layout>
+  );
+}

--- a/pages/500.js
+++ b/pages/500.js
@@ -1,0 +1,15 @@
+import Layout from "../components/Layout";
+import Link from "next/link";
+
+export default function ErrorPage() {
+  return (
+    <Layout>
+      <div className="text-center py-20">
+        <h1 className="text-4xl font-bold mb-4">Something went wrong</h1>
+        <Link href="/" className="text-blue-600 hover:underline">
+          Back home
+        </Link>
+      </div>
+    </Layout>
+  );
+}

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,0 +1,26 @@
+import { Html, Head, Main, NextScript } from 'next/document';
+
+function setInitialTheme() {
+  const stored = window.localStorage.getItem('theme');
+  const system = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  const theme = stored || system;
+  if (theme === 'dark') document.documentElement.classList.add('dark');
+}
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(${setInitialTheme.toString()})();`,
+          }}
+        />
+      </Head>
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  );
+}

--- a/pages/about.js
+++ b/pages/about.js
@@ -12,19 +12,36 @@ const skills = [
 export default function About() {
   return (
     <Layout>
-      <section className="bg-white/70 backdrop-blur rounded-xl p-6 shadow">
-        <h2 className="text-3xl font-bold mb-4">About Me</h2>
-        <p className="text-gray-700 leading-relaxed">
+      <section className="bg-white/70 dark:bg-gray-800/70 backdrop-blur rounded-xl p-6 shadow space-y-6">
+        <h2 className="text-3xl font-bold">About Me</h2>
+        <p className="text-gray-700 dark:text-gray-300 leading-relaxed">
           Provide a brief bio, your skills, or background here.
         </p>
-        <h3 className="text-2xl font-semibold mt-8 mb-4">Skills</h3>
-        <ul className="grid grid-cols-2 sm:grid-cols-3 gap-3">
-          {skills.map((skill) => (
-            <li key={skill} className="px-3 py-2 bg-blue-50 text-blue-700 rounded">
-              {skill}
-            </li>
-          ))}
-        </ul>
+        <div>
+          <h3 className="text-2xl font-semibold mb-3">Skills</h3>
+          <ul className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+            {skills.map((skill) => (
+              <li key={skill} className="px-3 py-2 bg-blue-50 text-blue-700 rounded dark:bg-blue-900 dark:text-blue-100">
+                {skill}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-2xl font-semibold mb-3">Timeline</h3>
+          <p className="text-gray-600 dark:text-gray-400">Timeline placeholder</p>
+        </div>
+        <div>
+          <h3 className="text-2xl font-semibold mb-3">Awards</h3>
+          <p className="text-gray-600 dark:text-gray-400">Awards placeholder</p>
+        </div>
+        <a
+          href="/cv.pdf"
+          className="inline-block mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"
+          download
+        >
+          Download CV
+        </a>
       </section>
     </Layout>
   );

--- a/pages/api/contact.js
+++ b/pages/api/contact.js
@@ -6,12 +6,13 @@ export default async function handler(req, res) {
     return res.status(405).json({ message: 'Method Not Allowed' });
   }
 
-  const { name, email, message } = req.body || {};
+  const { name, email, message, nickname } = req.body || {};
 
   if (
     typeof name !== 'string' ||
     typeof email !== 'string' ||
     typeof message !== 'string' ||
+    (nickname && nickname.trim() !== '') ||
     !name.trim() ||
     !message.trim() ||
     !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)

--- a/pages/contact.js
+++ b/pages/contact.js
@@ -4,7 +4,7 @@ import { useRouter } from "next/router";
 
 export default function Contact() {
   const router = useRouter();
-  const [form, setForm] = useState({ name: "", email: "", message: "" });
+  const [form, setForm] = useState({ name: "", email: "", message: "", nickname: "" });
   const [status, setStatus] = useState(null);
 
   const handleChange = (e) => {
@@ -13,6 +13,10 @@ export default function Contact() {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
+    if (form.nickname) {
+      // honeypot filled
+      return;
+    }
     if (!form.name || !form.email || !form.message) {
       setStatus({ type: "error", message: "Please complete all fields." });
       return;
@@ -27,7 +31,7 @@ export default function Contact() {
 
       if (res.ok) {
         setStatus({ type: "success", message: "Message sent!" });
-        setForm({ name: "", email: "", message: "" });
+        setForm({ name: "", email: "", message: "", nickname: "" });
       } else {
         setStatus({ type: "error", message: "Something went wrong." });
       }
@@ -39,47 +43,61 @@ export default function Contact() {
   return (
     <Layout>
       <h2 className="text-2xl font-bold mb-4">Contact</h2>
-      <p className="text-gray-700 mb-6">
+      <p className="text-gray-700 dark:text-gray-300 mb-6">
         Interested in working together? Fill out the form below or send me an email.
       </p>
-      <form className="grid gap-4 max-w-md" onSubmit={handleSubmit}>
-        <input
-          type="text"
-          name="name"
-          placeholder="Your name"
-          className="border rounded p-2"
-          value={form.name}
-          onChange={handleChange}
-        />
-        <input
-          type="email"
-          name="email"
-          placeholder="Your email"
-          className="border rounded p-2"
-          value={form.email}
-          onChange={handleChange}
-        />
-        <textarea
-          rows="4"
-          name="message"
-          placeholder="Message"
-          className="border rounded p-2"
-          value={form.message}
-          onChange={handleChange}
-        />
-        <button className="bg-blue-600 text-white py-2 rounded" type="submit">
+      <form className="grid gap-4 max-w-md" onSubmit={handleSubmit} noValidate>
+        <div className="hidden">
+          <label htmlFor="nickname">Nickname</label>
+          <input id="nickname" name="nickname" value={form.nickname} onChange={handleChange} tabIndex="-1" autoComplete="off" />
+        </div>
+        <div>
+          <label htmlFor="name" className="block mb-1">Name</label>
+          <input
+            id="name"
+            type="text"
+            name="name"
+            required
+            className="border rounded p-2 w-full dark:bg-gray-700 dark:border-gray-600"
+            value={form.name}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label htmlFor="email" className="block mb-1">Email</label>
+          <input
+            id="email"
+            type="email"
+            name="email"
+            required
+            className="border rounded p-2 w-full dark:bg-gray-700 dark:border-gray-600"
+            value={form.email}
+            onChange={handleChange}
+          />
+        </div>
+        <div>
+          <label htmlFor="message" className="block mb-1">Message</label>
+          <textarea
+            id="message"
+            rows="4"
+            name="message"
+            required
+            className="border rounded p-2 w-full dark:bg-gray-700 dark:border-gray-600"
+            value={form.message}
+            onChange={handleChange}
+          />
+        </div>
+        <button className="bg-blue-600 text-white py-2 rounded hover:bg-blue-700" type="submit">
           Send
         </button>
       </form>
-      {status && (
-        <p
-          className={`mt-4 ${
-            status.type === "success" ? "text-green-600" : "text-red-600"
-          }`}
-        >
-          {status.message}
-        </p>
-      )}
+      <p className="mt-4" aria-live="polite">
+        {status && (
+          <span className={status.type === "success" ? "text-green-600" : "text-red-600"}>
+            {status.message}
+          </span>
+        )}
+      </p>
     </Layout>
   );
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -20,31 +20,31 @@ export default function Home() {
 
   return (
     <Layout>
-      <section className="text-center py-20 bg-gradient-to-br from-blue-50 to-purple-100 rounded-xl shadow">
+      <section className="text-center py-20 bg-gradient-to-br from-blue-50 to-purple-100 dark:from-gray-700 dark:to-gray-800 rounded-xl shadow">
         <img
           src="https://via.placeholder.com/128"
           alt="Profile"
           className="w-32 h-32 rounded-full mx-auto mb-6 border-4 border-white shadow-lg"
         />
         <h2 className="text-4xl font-extrabold mb-3">Hello, I'm Khalid Khan</h2>
-        <p className="mb-8 text-gray-700 text-lg">
+        <p className="mb-8 text-gray-700 dark:text-gray-300 text-lg">
           I'm a <span className="text-blue-600">{titles[current]}</span>
         </p>
         <div className="flex justify-center gap-4 mb-8">
           <Link
             href="/projects"
-            className="px-6 py-3 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700"
+            className="px-6 py-3 bg-blue-600 text-white rounded-md shadow hover:bg-blue-700 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
           >
             View Projects
           </Link>
           <Link
             href="/contact"
-            className="px-6 py-3 border border-blue-600 text-blue-600 rounded-md hover:bg-blue-50"
+            className="px-6 py-3 border border-blue-600 text-blue-600 rounded-md hover:bg-blue-50 focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500 dark:hover:bg-gray-700"
           >
             Contact Me
           </Link>
         </div>
-        <div className="flex justify-center gap-6 text-gray-600">
+        <div className="flex justify-center gap-6 text-gray-600 dark:text-gray-300">
           <a
             href="https://github.com/khalidkhan76770"
             aria-label="GitHub"

--- a/public/cv.pdf
+++ b/public/cv.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT /F1 24 Tf 100 700 Td (CV Placeholder) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /Name /F1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000061 00000 n 
+0000000115 00000 n 
+0000000219 00000 n 
+0000000314 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+378
+%%EOF

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -5,5 +5,15 @@
 @tailwind utilities;
 
 body {
-  @apply font-sans bg-gradient-to-br from-white to-gray-100 text-gray-900;
+  @apply font-sans bg-white text-gray-900 dark:bg-gray-900 dark:text-gray-100;
+}
+
+*:focus-visible {
+  @apply outline-none ring-2 ring-offset-2 ring-blue-500;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    @apply animate-none transition-none;
+  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,10 +1,17 @@
 module.exports = {
+  darkMode: 'class',
   content: ["./pages/**/*.{js,jsx}", "./components/**/*.{js,jsx}"],
   theme: {
     extend: {
       fontFamily: {
         sans: ['Inter', 'sans-serif'],
       },
+      boxShadow: {
+        'soft': '0 4px 6px rgba(0,0,0,0.1)',
+      },
+      borderRadius: {
+        'xl': '1rem',
+      }
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- add script-based light/dark theme with toggle and focus-trapped mobile menu
- improve contact form with honeypot spam trap and accessible labels
- include placeholder CV, 404/500 pages, and dark-mode aware styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6c13e3f5c8323901b6e4b3095472f