### PR TITLE
Make placeholder links functional

### DIFF
--- a/components/sections/Contact.jsx
+++ b/components/sections/Contact.jsx
@@ -1,9 +1,21 @@
+import { meta } from "@/lib/data";
+
 export default function Contact() {
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const formData = new FormData(e.target);
+    const subject = encodeURIComponent(formData.get("subject") || "");
+    const body = encodeURIComponent(
+      `Name: ${formData.get("name")}\nEmail: ${formData.get("email")}\n\n${formData.get("message")}`
+    );
+    window.location.href = `mailto:${meta.email}?subject=${subject}&body=${body}`;
+  };
+
   return (
     <section id="contact" className="section section-pad mb-24">
       <div className="card p-6">
         <h2 className="text-2xl md:text-3xl font-semibold">Contact</h2>
-        <form onSubmit={(e) => { e.preventDefault(); alert('This form is a placeholder. Wire it to Web3Forms or Formspree.'); }} className="mt-6 grid sm:grid-cols-2 gap-4">
+        <form onSubmit={handleSubmit} className="mt-6 grid sm:grid-cols-2 gap-4">
           <input name="name" placeholder="Full name" className="border rounded-xl p-3" required />
           <input type="email" name="email" placeholder="Email address" className="border rounded-xl p-3" required />
           <input name="subject" placeholder="Subject" className="sm:col-span-2 border rounded-xl p-3" />

--- a/lib/data.js
+++ b/lib/data.js
@@ -30,7 +30,7 @@ export const projects = [
     summary: "Clean admin dashboard UI with auth placeholders and charts.",
     image: "/images/placeholder-1.jpg",
     tech: ["Next.js", "Tailwind"],
-    demo: "#",
+    demo: "https://github.com/khalidkhan76770",
     code: "https://github.com/khalidkhan76770"
   },
   {
@@ -39,7 +39,7 @@ export const projects = [
     summary: "Product grid, cart drawer, and checkout screens. Dummy API.",
     image: "/images/placeholder-2.jpg",
     tech: ["React", "CSS"],
-    demo: "#",
+    demo: "https://github.com/khalidkhan76770",
     code: "https://github.com/khalidkhan76770"
   },
   {
@@ -48,7 +48,7 @@ export const projects = [
     summary: "Markdown posts, tags, and search with static export.",
     image: "/images/placeholder-3.jpg",
     tech: ["Next.js", "Tailwind"],
-    demo: "#",
+    demo: "https://github.com/khalidkhan76770",
     code: "https://github.com/khalidkhan76770"
   },
   {
@@ -57,7 +57,7 @@ export const projects = [
     summary: "Auth screens and profile settings wired to a mock service.",
     image: "/images/placeholder-4.jpg",
     tech: ["React", "Bootstrap"],
-    demo: "#",
+    demo: "https://github.com/khalidkhan76770",
     code: "https://github.com/khalidkhan76770"
   },
 


### PR DESCRIPTION
## Summary
- Replace project demo placeholders with active GitHub links
- Convert contact form into mailto submission for immediate use

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa045ebe90832393fd43ea17a17031