### PR TITLE
Expose contact email in footer and ensure form opens mail client

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -1,3 +1,5 @@
+import { meta } from "@/lib/data";
+
 export default function Footer() {
   return (
     <footer className="border-t mt-16">
@@ -6,7 +8,7 @@ export default function Footer() {
         <div className="flex gap-4">
           <a href="https://github.com/khalidkhan76770" target="_blank" rel="noreferrer" className="hover:text-blue-600">GitHub</a>
           <a href="https://www.linkedin.com/in/khalidkhan76770" target="_blank" rel="noreferrer" className="hover:text-blue-600">LinkedIn</a>
-          <a href="mailto:khalid.khan.76770@gmail.com" className="hover:text-blue-600">Email</a>
+          <a href={`mailto:${meta.email}`} className="hover:text-blue-600">{meta.email}</a>
         </div>
       </div>
     </footer>

--- a/components/sections/Contact.jsx
+++ b/components/sections/Contact.jsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { meta } from "@/lib/data";
 
 export default function Contact() {


### PR DESCRIPTION
## Summary
- display direct email address in site footer using shared meta data
- mark contact form as a client component so the send button launches a mailto link

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa34e2f6308323b9faa4e5251523a2