### PR TITLE
fix: enable email links in contact form and footer

### DIFF
--- a/__tests__/Footer.test.js
+++ b/__tests__/Footer.test.js
@@ -1,0 +1,12 @@
+import { render, screen } from '@testing-library/react';
+import Footer from '../components/Footer';
+import { meta } from '../lib/data';
+
+describe('Footer', () => {
+  it('has working email link', () => {
+    render(<Footer />);
+    const link = screen.getByText('Email');
+    expect(link).toHaveAttribute('href', `mailto:${meta.email}`);
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+});

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -8,7 +8,14 @@ export default function Footer() {
         <div className="flex gap-4">
           <a href="https://github.com/khalidkhan76770" target="_blank" rel="noreferrer" className="hover:text-blue-600">GitHub</a>
           <a href="https://www.linkedin.com/in/khalidkhan76770" target="_blank" rel="noreferrer" className="hover:text-blue-600">LinkedIn</a>
-          <a href={`mailto:${meta.email}`} className="hover:text-blue-600">Email</a>
+          <a
+            href={`mailto:${meta.email}`}
+            target="_blank"
+            rel="noreferrer"
+            className="hover:text-blue-600"
+          >
+            Email
+          </a>
         </div>
       </div>
     </footer>

--- a/components/sections/Contact.jsx
+++ b/components/sections/Contact.jsx
@@ -10,7 +10,10 @@ export default function Contact() {
     const body = encodeURIComponent(
       `Name: ${formData.get("name")}\nEmail: ${formData.get("email")}\n\n${formData.get("message")}`
     );
-    window.location.href = `mailto:${meta.email}?subject=${subject}&body=${body}`;
+    window.open(
+      `https://mail.google.com/mail/?view=cm&fs=1&to=${meta.email}&su=${subject}&body=${body}`
+    );
+    e.target.reset();
   };
 
   return (


### PR DESCRIPTION
## Summary
- open contact form submissions in a Gmail compose window
- ensure footer Email button opens in a new tab
- add test verifying footer email link

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa385416a08323a1a769466c40be46