### PR TITLE
feat: deliver contact form via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 This is a Next.js portfolio site. It uses Tailwind CSS for styling and includes a simple API route for contact form submissions.
 
+## Contact form
+The contact form posts to `/api/send-email` and uses Nodemailer for delivery. Set the following environment variables so the API can send mail:
+- `SMTP_HOST`
+- `SMTP_PORT`
+- `SMTP_USER`
+- `SMTP_PASS`
+
 ## Scripts
 - `npm run dev` – start development server
 - `npm run build` – build for production

--- a/components/sections/Contact.jsx
+++ b/components/sections/Contact.jsx
@@ -1,19 +1,31 @@
 "use client";
 
-import { meta } from "@/lib/data";
+import { useState } from "react";
 
 export default function Contact() {
-  const handleSubmit = (e) => {
+  const [status, setStatus] = useState("");
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
+    setStatus("");
     const formData = new FormData(e.target);
-    const subject = encodeURIComponent(formData.get("subject") || "");
-    const body = encodeURIComponent(
-      `Name: ${formData.get("name")}\nEmail: ${formData.get("email")}\n\n${formData.get("message")}`
-    );
-    window.open(
-      `https://mail.google.com/mail/?view=cm&fs=1&to=${meta.email}&su=${subject}&body=${body}`
-    );
-    e.target.reset();
+    const data = Object.fromEntries(formData.entries());
+
+    try {
+      const res = await fetch("/api/send-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (res.ok) {
+        setStatus("Your mail has been sent successfully.");
+        e.target.reset();
+      } else {
+        setStatus("Failed to send message. Please try again later.");
+      }
+    } catch {
+      setStatus("Failed to send message. Please try again later.");
+    }
   };
 
   return (
@@ -30,6 +42,7 @@ export default function Contact() {
             <button className="btn-primary" type="submit">Send</button>
           </div>
         </form>
+        {status && <p className="mt-4 text-sm text-green-600">{status}</p>}
       </div>
     </section>
   );

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "framer-motion": "^10.18.0",
-    "clsx": "^2.1.0"
+    "clsx": "^2.1.0",
+    "nodemailer": "^6.9.12"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.0",

--- a/pages/api/send-email.js
+++ b/pages/api/send-email.js
@@ -1,0 +1,36 @@
+import nodemailer from "nodemailer";
+import { meta } from "@/lib/data";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  const { name, email, subject, message } = req.body;
+  if (!name || !email || !message) {
+    return res.status(400).json({ message: "Missing required fields" });
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: Number(process.env.SMTP_PORT) || 587,
+    secure: false,
+    auth: {
+      user: process.env.SMTP_USER,
+      pass: process.env.SMTP_PASS,
+    },
+  });
+
+  try {
+    await transporter.sendMail({
+      from: email,
+      to: meta.email,
+      subject: subject || "New Contact Form Message",
+      text: `Name: ${name}\nEmail: ${email}\n\n${message}`,
+    });
+    return res.status(200).json({ message: "Email sent successfully" });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ message: "Failed to send email" });
+  }
+}


### PR DESCRIPTION
## Summary
- send contact form data to a new `/api/send-email` route using Nodemailer
- show a status message after submitting instead of opening Gmail
- document SMTP environment vars and add Nodemailer dependency

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/nodemailer)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3c6157008323a3719f843ca25f32