### PR TITLE
feat: send contact form through SendGrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@
 
 This is a Next.js portfolio site. It uses Tailwind CSS for styling and includes a simple API route for contact form submissions.
 
+## Contact form
+The contact form posts to `/api/send-email` and sends email via the SendGrid API. Set the following environment variables so the API can send mail:
+- `SENDGRID_API_KEY`
+- `SENDGRID_FROM_EMAIL`
+
 ## Scripts
 - `npm run dev` – start development server
 - `npm run build` – build for production

--- a/components/sections/Contact.jsx
+++ b/components/sections/Contact.jsx
@@ -1,19 +1,31 @@
 "use client";
 
-import { meta } from "@/lib/data";
+import { useState } from "react";
 
 export default function Contact() {
-  const handleSubmit = (e) => {
+  const [status, setStatus] = useState("");
+
+  const handleSubmit = async (e) => {
     e.preventDefault();
+    setStatus("");
     const formData = new FormData(e.target);
-    const subject = encodeURIComponent(formData.get("subject") || "");
-    const body = encodeURIComponent(
-      `Name: ${formData.get("name")}\nEmail: ${formData.get("email")}\n\n${formData.get("message")}`
-    );
-    window.open(
-      `https://mail.google.com/mail/?view=cm&fs=1&to=${meta.email}&su=${subject}&body=${body}`
-    );
-    e.target.reset();
+    const data = Object.fromEntries(formData.entries());
+
+    try {
+      const res = await fetch("/api/send-email", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(data),
+      });
+      if (res.ok) {
+        setStatus("Message sent successfully.");
+        e.target.reset();
+      } else {
+        setStatus("Failed to send message. Please try again later.");
+      }
+    } catch {
+      setStatus("Failed to send message. Please try again later.");
+    }
   };
 
   return (
@@ -30,6 +42,7 @@ export default function Contact() {
             <button className="btn-primary" type="submit">Send</button>
           </div>
         </form>
+        {status && <p className="mt-4 text-sm text-green-600">{status}</p>}
       </div>
     </section>
   );

--- a/pages/api/send-email.js
+++ b/pages/api/send-email.js
@@ -1,0 +1,41 @@
+import { meta } from "@/lib/data";
+
+export default async function handler(req, res) {
+  if (req.method !== "POST") {
+    return res.status(405).json({ message: "Method not allowed" });
+  }
+
+  const { name, email, subject, message } = req.body;
+  if (!name || !email || !message) {
+    return res.status(400).json({ message: "Missing required fields" });
+  }
+
+  const payload = {
+    personalizations: [{ to: [{ email: meta.email }] }],
+    from: { email: process.env.SENDGRID_FROM_EMAIL || meta.email },
+    subject: subject || "New Contact Form Message",
+    content: [{ type: "text/plain", value: `Name: ${name}\nEmail: ${email}\n\n${message}` }],
+  };
+
+  try {
+    const sgRes = await fetch("https://api.sendgrid.com/v3/mail/send", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${process.env.SENDGRID_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!sgRes.ok) {
+      const errText = await sgRes.text();
+      console.error("SendGrid error", sgRes.status, errText);
+      return res.status(500).json({ message: "Failed to send email" });
+    }
+
+    return res.status(200).json({ message: "Email sent successfully" });
+  } catch (error) {
+    console.error(error);
+    return res.status(500).json({ message: "Failed to send email" });
+  }
+}


### PR DESCRIPTION
## Summary
- forward contact form submissions to a serverless route that calls SendGrid's API
- drop Nodemailer dependency so `npm install` works in the GitHub environment
- document SendGrid environment variables for configuring the mail sender
- simplify contact form success message

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa3c6157008323a3719f843ca25f32