### PR TITLE
Align contact form and update footer email link

### DIFF
--- a/__tests__/Footer.test.js
+++ b/__tests__/Footer.test.js
@@ -7,6 +7,6 @@ describe('Footer', () => {
     render(<Footer />);
     const link = screen.getByText('Email');
     expect(link).toHaveAttribute('href', `mailto:${meta.email}`);
-    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).not.toHaveAttribute('target');
   });
 });

--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -11,8 +11,6 @@ export default function Footer() {
             <a href="https://www.linkedin.com/in/khalidkhan76770" target="_blank" rel="noreferrer" className="hover:text-blue-600">LinkedIn</a>
             <a
               href={`mailto:${meta.email}`}
-              target="_blank"
-              rel="noreferrer"
               className="hover:text-blue-600"
             >
               Email

--- a/components/sections/Contact.jsx
+++ b/components/sections/Contact.jsx
@@ -35,7 +35,7 @@ export default function Contact() {
 
   return (
     <section id="contact" className="section section-pad mb-24">
-      <div className="card p-6 max-w-md mx-auto">
+      <div className="card p-6 max-w-md">
         <h2 className="text-2xl md:text-3xl font-semibold">Contact</h2>
         <form onSubmit={handleSubmit} className="mt-6 flex flex-col gap-2">
           <input name="name" placeholder="Full name" className="border rounded-xl p-3" required />


### PR DESCRIPTION
## Summary
- Align contact form with the left edge of other sections
- Keep footer email link in same tab and update test accordingly

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aa494700f48323897998d0b3c1be8b