### PR TITLE
Improve project cards with request-only links

### DIFF
--- a/components/ProjectCard.jsx
+++ b/components/ProjectCard.jsx
@@ -1,25 +1,49 @@
 import Image from "next/image";
+import { useState } from "react";
+import clsx from "clsx";
 
 export default function ProjectCard({ title, summary, image, tech = [], demo, code }) {
+  const [expanded, setExpanded] = useState(false);
+  const needsToggle = summary && summary.length > 100;
+
   return (
     <article className="card overflow-hidden">
       <div className="relative aspect-[16/10] bg-gray-50">
         {image && (
-          <Image src={image} alt={title} fill className="object-cover" />
+          <Image src={image} alt={title} fill className="object-contain" />
         )}
       </div>
       <div className="p-4">
         <h3 className="font-semibold">{title}</h3>
         {summary && (
-          <p className="text-sm text-gray-600 line-clamp-2 mt-1">{summary}</p>
+          <>
+            <p
+              className={clsx(
+                "text-sm text-gray-600 mt-1",
+                !expanded && "line-clamp-2"
+              )}
+            >
+              {summary}
+            </p>
+            {needsToggle && (
+              <button
+                className="text-xs text-blue-600 hover:underline mt-1"
+                onClick={() => setExpanded((v) => !v)}
+              >
+                {expanded ? "Read less" : "Read more"}
+              </button>
+            )}
+          </>
         )}
         <div className="flex flex-wrap gap-2 mt-3">
           {tech.map((t) => (
-            <span key={t} className="chip">{t}</span>
+            <span key={t} className="chip">
+              {t}
+            </span>
           ))}
         </div>
         <div className="mt-4 flex gap-3">
-          {demo && demo !== "#" && (
+          {demo ? (
             <a
               className="text-sm text-blue-600 hover:underline"
               href={demo}
@@ -28,8 +52,10 @@ export default function ProjectCard({ title, summary, image, tech = [], demo, co
             >
               Live Demo
             </a>
+          ) : (
+            <span className="text-sm text-gray-600">Live Demo upon request</span>
           )}
-          {code && (
+          {code ? (
             <a
               className="text-sm text-blue-600 hover:underline"
               href={code}
@@ -38,6 +64,8 @@ export default function ProjectCard({ title, summary, image, tech = [], demo, co
             >
               Live Code
             </a>
+          ) : (
+            <span className="text-sm text-gray-600">Live Code upon request</span>
           )}
         </div>
       </div>

--- a/lib/data.js
+++ b/lib/data.js
@@ -23,15 +23,15 @@ export const certificates = [
 
 // 6 projects total
 export const projects = [
-  // 4 placeholders that point to your GitHub home for now
+  // 3 back-end projects; links available upon request
   {
     title: "Fine-tuning LLaMA for COVID-19 Spike Protein Sequence Classification",
     slug: "spike-sequence-finetune",
     summary: "This project extracts spike protein regions from viral genomes, builds a labeled dataset, and fine-tunes a long-context LLaMA model with LoRA and 4-bit quantization to classify sequences by country of origin. The trained model is deployed via a FastAPI service and packaged with Docker for easy GPU-based inference.",
     image: "/portfolio/spike-sequence-finetune.png",
     tech: ["Python", "Uvicorn", "PyTorch", "NumPy", "SciPy", "Docker", "Pytest"],
-    demo: "https://github.com/khalidkhan76770",
-    code: "https://github.com/khalidkhan76770"
+    demo: null,
+    code: null
   },
   {
     title: "Evo2‑1b Fine‑tuning for SARS‑CoV‑2 Variant Classification",
@@ -39,8 +39,8 @@ export const projects = [
     summary: "The project applies NVIDIA’s BioNeMo framework to fine‑tune the Evo2‑1b model on COVID‑19 spike‑protein sequences, enabling classification of different SARS‑CoV‑2 variants after dedicated preprocessing, checkpoint handling, and analysis routines.",
     image: "/portfolio/evo-finetuning.png",
     tech: ["Python", "NVIDIA", "Docker", "PyTorch", "Scikit-learn", "TensorBoard", "Matplotlib"],
-    demo: "https://github.com/khalidkhan76770",
-    code: "https://github.com/khalidkhan76770"
+    demo: null,
+    code: null
   },
   {
     title: "Blog Platform",
@@ -48,9 +48,11 @@ export const projects = [
     summary: "Markdown posts, tags, and search with static export.",
     image: "/portfolio/placeholder-3.jpg",
     tech: ["Next.js", "Tailwind"],
-    demo: "https://github.com/khalidkhan76770",
-    code: "https://github.com/khalidkhan76770"
+    demo: null,
+    code: null
   },
+
+  // 3 public projects with accessible code
   {
     title: "Auth and Profile",
     slug: "auth-profile",


### PR DESCRIPTION
## Summary
- show project images at full height
- add optional read more toggle for project summaries
- mark first three projects as request-only with no public demo or code links

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad9526c1a48323bd1ce7cc1440981a