### PR TITLE
Expand skills with technologies from six projects

### DIFF
--- a/lib/data.js
+++ b/lib/data.js
@@ -9,10 +9,54 @@ export const meta = {
 };
 
 export const skills = {
-  frontend: ["HTML", "CSS", "JavaScript", "React", "Next.js", "Tailwind", "Bootstrap"],
-  backend: ["Node.js", "PHP", "MySQL", "Spring Boot"],
-  other: ["Responsive Web Design", "Git and GitHub", "CMS (WordPress, Shopify)", "Debugging", "Performance optimization"],
-  tools: ["Vercel", "Jest", "Photoshop"]
+  frontend: [
+    "HTML5",
+    "CSS3",
+    "JavaScript (ES6)",
+    "React",
+    "Next.js",
+    "Tailwind",
+    "Bootstrap",
+    "React DOM",
+    "Framer Motion",
+    "PostCSS",
+  ],
+  backend: [
+    "Node.js",
+    "PHP",
+    "MySQL",
+    "Spring Boot",
+    "Python",
+    "Uvicorn",
+    "PyTorch",
+    "NumPy",
+    "SciPy",
+    "Scikit-learn",
+    "Matplotlib",
+    "SQL",
+    "Google API PHP Client",
+    "OAuth 2.0",
+  ],
+  other: [
+    "Responsive Web Design",
+    "Git and GitHub",
+    "CMS (WordPress, Shopify)",
+    "Debugging",
+    "Performance optimization",
+    "NVIDIA",
+    "Production Troubleshooting",
+  ],
+  tools: [
+    "Vercel",
+    "Jest",
+    "Photoshop",
+    "Docker",
+    "Pytest",
+    "Testing Library",
+    "Composer",
+    "cPanel",
+    "TensorBoard",
+  ],
 };
 
 export const certificates = [


### PR DESCRIPTION
## Summary
- aggregate technologies across six portfolio projects and list them in the skills section
- catalog machine learning, backend, and tooling stacks used across projects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c5adbfedd483238355fb9a5430f7ac